### PR TITLE
remove unused function vf_index_is_selected

### DIFF
--- a/src/view_file.c
+++ b/src/view_file.c
@@ -168,20 +168,6 @@ static gboolean vf_release_cb(GtkWidget *widget, GdkEventButton *bevent, gpointe
  *-----------------------------------------------------------------------------
  */
 
-gboolean vf_index_is_selected(ViewFile *vf, gint row)
-{
-	gboolean ret = FALSE;
-
-	switch (vf->type)
-	{
-	case FILEVIEW_LIST: ret = vflist_index_is_selected(vf, row); break;
-	case FILEVIEW_ICON: ret = vficon_index_is_selected(vf, row); break;
-	}
-
-	return ret;
-}
-
-
 guint vf_selection_count(ViewFile *vf, gint64 *bytes)
 {
 	guint count = 0;

--- a/src/view_file.h
+++ b/src/view_file.h
@@ -46,7 +46,6 @@ gint vf_index_by_fd(ViewFile *vf, FileData *in_fd);
 guint vf_count(ViewFile *vf, gint64 *bytes);
 GList *vf_get_list(ViewFile *vf);
 
-gint vf_index_is_selected(ViewFile *vf, gint row);
 guint vf_selection_count(ViewFile *vf, gint64 *bytes);
 GList *vf_selection_get_list(ViewFile *vf);
 GList *vf_selection_get_list_by_index(ViewFile *vf);


### PR DESCRIPTION
The function vf_index_is_selected is not used anywhere throughout the
project. This patch removes it.